### PR TITLE
check utf-8 encoding, fix for content-type

### DIFF
--- a/backend/flask_api.py
+++ b/backend/flask_api.py
@@ -84,8 +84,9 @@ def add_project():
 
         except ApiException as e:
             raise e
-        except UnicodeError as ue:
-            raise ApiException("Request Body is not in utf-8: " + str(ue), 400)
+        except (UnicodeError, UnicodeDecodeError) as ue:
+            raise ApiException('Only utf-8 compatible charsets are supported, ' +
+                               'the request body does not appear to be utf-8.', 400)
         except Exception as err:
             raise ApiException(str(err), 400)
 

--- a/backend/flask_api.py
+++ b/backend/flask_api.py
@@ -72,9 +72,10 @@ def add_project():
     else:
         try:
             return_ids = []
-            if request.content_type == 'application/json':
+            if ('application/json' in request.content_type) and \
+                    ('application/json5' not in request.content_type):
                 return_ids = uploader.save_manifest_to_db(request.get_json())
-            elif request.content_type == 'application/json5':
+            elif 'application/json5' in request.content_type:
                 return_ids = uploader.save_manifest_to_db(
                     json5.loads(request.data.decode("utf-8")))
             else:
@@ -83,6 +84,8 @@ def add_project():
 
         except ApiException as e:
             raise e
+        except UnicodeError as ue:
+            raise ApiException("Request Body is not in utf-8: " + str(ue), 400)
         except Exception as err:
             raise ApiException(str(err), 400)
 

--- a/backend/flask_api.py
+++ b/backend/flask_api.py
@@ -77,14 +77,14 @@ def add_project():
                 return_ids = uploader.save_manifest_to_db(request.get_json())
             elif 'application/json5' in request.content_type:
                 return_ids = uploader.save_manifest_to_db(
-                    json5.loads(request.data.decode("utf-8")))
+                    json5.loads(request.data.decode('utf-8')))
             else:
                 raise ApiException("Wrong content header and no files attached", 400)
             return jsonify(return_ids)
 
         except ApiException as e:
             raise e
-        except (UnicodeError, UnicodeDecodeError) as ue:
+        except UnicodeDecodeError as ue:
             raise ApiException('Only utf-8 compatible charsets are supported, ' +
                                'the request body does not appear to be utf-8.', 400)
         except Exception as err:

--- a/backend/uploader.py
+++ b/backend/uploader.py
@@ -97,12 +97,8 @@ def save_manifest_to_db(manifest):
         is_valid = validator.is_valid(manifest)
 
         if is_valid:
-            manifestlist = []
+            manifestlist = manifest if isinstance(manifest, list) else [manifest]
             ids = []
-            if isinstance(manifest, list):
-                manifestlist = manifest
-            else:
-                manifestlist.append(manifest)
 
             for entry in manifestlist:
                 entry['date_creation'] = time.strftime("%Y-%m-%d")

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -57,7 +57,7 @@ class TestPOST(object):
         print(data)
         data32 = data.encode('utf-32')
         response = requests.post(flask_api_url + "/api/projects", data=data32,
-                                 headers={'Content-Type': 'application/json'})
+                                 headers={'Content-Type': 'application/json5'})
         assert response.status_code == 400
         assert 'request body does not appear to be utf-8' in response.text
 

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -5,6 +5,7 @@ import uuid
 
 from uuid import UUID
 
+
 class TestPOST(object):
 
     def test_empty_post(self, flask_api_url):

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -52,13 +52,14 @@ class TestPOST(object):
             'testmanifests',
             'validexample0.json'
         )
-        with open(test_manifest, 'r', encoding='UTF-32') as tf:
+        with open(test_manifest, 'r', encoding='UTF-8') as tf:
             data = str(tf.read().replace('\n', ''))
         print(data)
-        response = requests.post(flask_api_url + "/api/projects", data=data,
+        data32 = data.encode('utf-32')
+        response = requests.post(flask_api_url + "/api/projects", data=data32,
                                  headers={'Content-Type': 'application/json'})
         assert response.status_code == 400
-        assert 'not in utf-8' in response.text
+        assert 'request body does not appear to be utf-8' in response.text
 
     def test_validation_error(self, flask_api_url, pytestconfig):
         test_manifest = os.path.join(

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -45,6 +45,21 @@ class TestPOST(object):
         for id in response.json():
             assert UUID(id, version=4)
 
+    def test_encoding_error(self, flask_api_url, pytestconfig):
+        test_manifest = os.path.join(
+            str(pytestconfig.rootdir),
+            'tests',
+            'testmanifests',
+            'validexample0.json'
+        )
+        with open(test_manifest, 'r', encoding='UTF-32') as tf:
+            data = str(tf.read().replace('\n', ''))
+        print(data)
+        response = requests.post(flask_api_url + "/api/projects", data=data,
+                                 headers={'Content-Type': 'application/json'})
+        assert response.status_code == 400
+        assert 'not in utf-8' in response.text
+
     def test_validation_error(self, flask_api_url, pytestconfig):
         test_manifest = os.path.join(
             str(pytestconfig.rootdir),

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -1,10 +1,9 @@
 import json
 import os
-from uuid import UUID
+import requests
 import uuid
 
-import requests
-
+from uuid import UUID
 
 class TestPOST(object):
 


### PR DESCRIPTION
header content-type can now contain more than only 'application/json[5]', such as 'application/json; charset: utf-8' see #133 