### PR TITLE
Put setup of date_creation before verifying step

### DIFF
--- a/backend/api/helper/uploader.py
+++ b/backend/api/helper/uploader.py
@@ -43,11 +43,12 @@ def save_file_to_db(file, filename):
         if not jsonstr:
             raise ApiException('File ' + str(filename) + ' is empty.', 400)
         manifest = json5.loads(jsonstr)
+
+        if not manifest['date_creation']:
+            manifest['date_creation'] = time.strftime("%Y-%m-%d")
         is_valid = g.validator.is_valid(manifest)
 
         if is_valid:
-            if not manifest['date_creation']:
-                manifest['date_creation'] = time.strftime("%Y-%m-%d")
             manifest['date_last_updated'] = time.strftime("%Y-%m-%d")
             manifest['_id'] = uuid.uuid4()
             g.projects.insert_one(manifest)
@@ -78,15 +79,17 @@ def save_manifest_to_db(manifest):
         ApiException: Error while trying to save the documents.
     """
     try:
-        is_valid = g.validator.is_valid(manifest)
+        manifestlist = manifest if isinstance(manifest, list) else [manifest]
+        for entry in manifestlist:
+            if not entry['date_creation']:
+                entry['date_creation'] = time.strftime("%Y-%m-%d")
+
+        is_valid = g.validator.is_valid(manifestlist)
 
         if is_valid:
-            manifestlist = manifest if isinstance(manifest, list) else [manifest]
             ids = []
 
             for entry in manifestlist:
-                if not entry['date_creation']:
-                    entry['date_creation'] = time.strftime("%Y-%m-%d")
                 entry['date_last_updated'] = time.strftime("%Y-%m-%d")
                 entry['_id'] = uuid.uuid4()
                 g.projects.insert(entry)


### PR DESCRIPTION
I did changes in uploader.py. The "date_creation" is a required field. Setting of this field after verifying, would make no sense. In case of missing field it has to be set before verifying otherwise verification is failing anyway and it will never be set. I am sorry, but I could not test. Docker did not build the master. I have to check, what is the problem. Maybe you could check if these changes are running.