### PR TITLE
[BE] Added tests for invalid and unknown id for put

### DIFF
--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -336,7 +336,7 @@ class TestPUT(object):
         invalid_id = "invalid"
         response = requests.put(flask_api_url + "/api/projects/" + invalid_id)
         print(response.text)
-        assert response.status_code == 404
+        assert response.status_code == 405
 
     def test_success(self, flask_api_url):
         assert True

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -276,7 +276,7 @@ class TestDELETE(object):
 class TestGET(object):
 
     def test_unknown_id(self, flask_api_url):
-        """ Test for 404 when a project with unknown ID is to be deleted.
+        """ Test for 404 when one tries to get a project with unknown ID.
         """
         unknown_id = str(uuid.uuid4())
         response = requests.get(flask_api_url + "/api/projects/" + unknown_id)
@@ -284,7 +284,7 @@ class TestGET(object):
         assert response.status_code == 404
 
     def test_invalid_id(self, flask_api_url):
-        """ Test for 404 when a project with ID in invalid format is to be deleted.
+        """ Test for 404 when one tries to get a project with ID in invalid format.
         """
         invalid_id = "invalid"
         response = requests.get(flask_api_url + "/api/projects/" + invalid_id)
@@ -323,7 +323,20 @@ class TestGET(object):
 class TestPUT(object):
 
     def test_unknown_id(self, flask_api_url):
-        assert True
+        """ Test for 404 when one tries to put a project with unknown ID.
+        """
+        unknown_id = str(uuid.uuid4())
+        response = requests.put(flask_api_url + "/api/projects/" + unknown_id)
+        print(response.text)
+        assert response.status_code == 404
+
+    def test_invalid_id(self, flask_api_url):
+        """ Test for 404 when one tries to put a project with ID in invalid format.
+        """
+        invalid_id = "invalid"
+        response = requests.put(flask_api_url + "/api/projects/" + invalid_id)
+        print(response.text)
+        assert response.status_code == 404
 
     def test_success(self, flask_api_url):
         assert True

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -331,7 +331,7 @@ class TestPUT(object):
         assert response.status_code == 404
 
     def test_invalid_id(self, flask_api_url):
-        """ Test for 404 when one tries to put a project with ID in invalid format.
+        """ Test for 405 when one tries to put a project with ID in invalid format.
         """
         invalid_id = "invalid"
         response = requests.put(flask_api_url + "/api/projects/" + invalid_id)


### PR DESCRIPTION
Added both tests for invalid and unknown ID for PUT on /api/projects/ for Issue #105 .
__Update:__ Now test_invalid_id works, too. I was somehow under the impression itshould raise a 404 but it should raise a 405, so that's fine now, too.

I also updated the docstring of the get tests because those were accidentally talking about delete.