### PR TITLE
[BE] Consistent Delete Test + Fix for old DELETE test

### DIFF
--- a/tests/api/test_database_connection.py
+++ b/tests/api/test_database_connection.py
@@ -67,7 +67,7 @@ def test_consistent_delete(flask_api_url, mongo_client, elastic_client):
     delete_response = requests.delete(flask_api_url + "/api/projects/" + str(project_id))
     print(delete_response.text)
     assert delete_response.status_code == 200
-    
+
     # wait for the refreshed elastic database
     time.sleep(5)
     es_d_result = elastic_client.get(index="knexdb", id=project_id, ignore=404)

--- a/tests/api/test_database_connection.py
+++ b/tests/api/test_database_connection.py
@@ -67,6 +67,8 @@ def test_consistent_delete(flask_api_url, mongo_client, elastic_client):
     delete_response = requests.delete(flask_api_url + "/api/projects/" + str(project_id))
     print(delete_response.text)
     assert delete_response.status_code == 200
-
+    
+    # wait for the refreshed elastic database
+    time.sleep(5)
     es_d_result = elastic_client.get(index="knexdb", id=project_id, ignore=404)
     assert not es_d_result['found']

--- a/tests/api/test_database_connection.py
+++ b/tests/api/test_database_connection.py
@@ -1,6 +1,7 @@
 import time
 import uuid
 import requests
+import pytest
 
 
 def test_no_mongo(flask_api_url, docker_client):
@@ -40,3 +41,34 @@ def test_consistency(mongo_client, elastic_client):
     es_result = elastic_client.get(index="knexdb", id=project_id)
     print("es:", es_result)
     assert es_result['found']
+
+def test_consistent_delete(flask_api_url, mongo_client, elastic_client, capsys):
+    """ Test whether files deleted in mongodb also get deleted in elasticsearch.
+    """
+    project_id = uuid.uuid4()
+    dummy_project = {"_id": project_id, "name": "dummy_file"}
+    mongo_client.projects.insert_one(dummy_project)
+    mongo_result = mongo_client.projects.find_one(project_id)
+    print("mongo:", mongo_result)
+    # Test if document is in mongo
+    assert mongo_result == dummy_project
+    # wait for the refreshed elastic database
+    time.sleep(5)
+    # test if document is in es
+    # print es indices ( for easier debugging)
+    for index in elastic_client.indices.get('*'):
+        print(index)
+
+    es_result = elastic_client.get(index="knexdb", id=project_id)
+    print("es:", es_result)
+    assert es_result['found']
+
+    # delete from mongo and check es
+    delete_response = requests.delete(flask_api_url + "/api/projects/" + str(project_id))
+    print(delete_response.text)
+    assert delete_response.status_code == 200
+
+    es_d_result = elastic_client.get(index="knexdb", id=project_id)
+    print (es_d_result)
+    assert '404' in es_d_result
+

--- a/tests/api/test_database_connection.py
+++ b/tests/api/test_database_connection.py
@@ -1,7 +1,6 @@
 import time
 import uuid
 import requests
-import pytest
 
 
 def test_no_mongo(flask_api_url, docker_client):

--- a/tests/api/test_database_connection.py
+++ b/tests/api/test_database_connection.py
@@ -42,6 +42,7 @@ def test_consistency(mongo_client, elastic_client):
     print("es:", es_result)
     assert es_result['found']
 
+
 def test_consistent_delete(flask_api_url, mongo_client, elastic_client):
     """ Test whether files deleted in mongodb also get deleted in elasticsearch.
     """
@@ -64,10 +65,10 @@ def test_consistent_delete(flask_api_url, mongo_client, elastic_client):
     assert es_result['found']
 
     # delete from mongo and check es
-    delete_response = requests.delete(flask_api_url + "/api/projects/" + str(project_id))
+    delete_response = requests.delete(
+        flask_api_url + "/api/projects/" + str(project_id))
     print(delete_response.text)
     assert delete_response.status_code == 200
 
     es_d_result = elastic_client.get(index="knexdb", id=project_id, ignore=404)
     assert not es_d_result['found']
-

--- a/tests/api/test_database_connection.py
+++ b/tests/api/test_database_connection.py
@@ -42,7 +42,7 @@ def test_consistency(mongo_client, elastic_client):
     print("es:", es_result)
     assert es_result['found']
 
-def test_consistent_delete(flask_api_url, mongo_client, elastic_client, capsys):
+def test_consistent_delete(flask_api_url, mongo_client, elastic_client):
     """ Test whether files deleted in mongodb also get deleted in elasticsearch.
     """
     project_id = uuid.uuid4()
@@ -68,7 +68,6 @@ def test_consistent_delete(flask_api_url, mongo_client, elastic_client, capsys):
     print(delete_response.text)
     assert delete_response.status_code == 200
 
-    es_d_result = elastic_client.get(index="knexdb", id=project_id)
-    print (es_d_result)
-    assert '404' in es_d_result
+    es_d_result = elastic_client.get(index="knexdb", id=project_id, ignore=404)
+    assert not es_d_result['found']
 

--- a/tests/api/test_database_connection.py
+++ b/tests/api/test_database_connection.py
@@ -65,8 +65,7 @@ def test_consistent_delete(flask_api_url, mongo_client, elastic_client):
     assert es_result['found']
 
     # delete from mongo and check es
-    delete_response = requests.delete(
-        flask_api_url + "/api/projects/" + str(project_id))
+    delete_response = requests.delete(flask_api_url + "/api/projects/" + str(project_id))
     print(delete_response.text)
     assert delete_response.status_code == 200
 

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -41,8 +41,7 @@ class TestPOST(object):
         )
         with open(test_manifest, 'r') as tf:
             test_manifest_json = json.load(tf)
-        response = requests.post(
-            flask_api_url + "/api/projects", json=test_manifest_json)
+        response = requests.post(flask_api_url + "/api/projects", json=test_manifest_json)
         print(response.text)
         for id in response.json():
             assert UUID(id, version=4)
@@ -131,8 +130,7 @@ class TestPOST(object):
         with open(unmatching_manifest, 'r', encoding='utf-8') as tf:
             unmatching_data = str(tf.read().replace('\n', ''))
         unmatching_response = requests.post(flask_api_url + "/api/projects",
-                                            data=unmatching_data.encode(
-                                                'utf-8'),
+                                            data=unmatching_data.encode('utf-8'),
                                             headers={'Content-Type': 'application/json5'})
         print(unmatching_response.text)
 
@@ -226,8 +224,7 @@ class TestDELETE(object):
         """ Test for 404 when a project with unknown ID is to be deleted.
         """
         unknown_id = str(uuid.uuid4())
-        response = requests.delete(
-            flask_api_url + "/api/projects/" + unknown_id)
+        response = requests.delete(flask_api_url + "/api/projects/" + unknown_id)
         print(response.text)
         assert response.status_code == 404
 
@@ -236,8 +233,7 @@ class TestDELETE(object):
             The method does expect a uuid, a string will return invalid method
         """
         invalid_id = "invalid"
-        response = requests.delete(
-            flask_api_url + "/api/projects/" + invalid_id)
+        response = requests.delete(flask_api_url + "/api/projects/" + invalid_id)
         print(response.text)
         assert response.status_code == 405
 
@@ -253,8 +249,7 @@ class TestDELETE(object):
         )
         with open(test_manifest, 'r') as tf:
             test_manifest_json = json.load(tf)
-        post_response = requests.post(
-            flask_api_url + "/api/projects", json=test_manifest_json)
+        post_response = requests.post(flask_api_url + "/api/projects", json=test_manifest_json)
         print(post_response.text)
         for id in post_response.json():
             assert UUID(id, version=4)
@@ -262,8 +257,7 @@ class TestDELETE(object):
 
         # Delete
         project_id = post_response.json()[0]
-        delete_response = requests.delete(
-            flask_api_url + "/api/projects/" + project_id)
+        delete_response = requests.delete(flask_api_url + "/api/projects/" + project_id)
         print(delete_response.text)
         assert delete_response.status_code == 200
 
@@ -276,14 +270,12 @@ class TestDELETE(object):
         )
         with open(test_manifest, 'r') as tf:
             test_manifest_json = json.load(tf)
-        post_response = requests.post(
-            flask_api_url + "/api/projects", json=test_manifest_json)
+        post_response = requests.post(flask_api_url + "/api/projects", json=test_manifest_json)
         print(post_response.text)
         for id in post_response.json():
             assert UUID(id, version=4)
         project_id = post_response.json()[0]
-        delete_response = requests.delete(
-            flask_api_url + "/api/projects/" + project_id)
+        delete_response = requests.delete(flask_api_url + "/api/projects/" + project_id)
         print(delete_response.text)
         assert delete_response.status_code == 200
 
@@ -321,21 +313,18 @@ class TestGET(object):
         )
         with open(test_manifest, 'r') as tf:
             test_manifest_json = json.load(tf)
-        post_response = requests.post(
-            flask_api_url + "/api/projects", json=test_manifest_json)
+        post_response = requests.post(flask_api_url + "/api/projects", json=test_manifest_json)
         print(post_response.text)
         for id in post_response.json():
             assert UUID(id, version=4)
 
         project_id = post_response.json()[0]
-        get_response = requests.get(
-            flask_api_url + "/api/projects/" + project_id)
+        get_response = requests.get(flask_api_url + "/api/projects/" + project_id)
         print(get_response.text)
 
         assert get_response.status_code == 200
         assert get_response.json()["title"] == test_manifest_json["title"]
-        assert get_response.json()["analysis"] == test_manifest_json[
-            "analysis"]
+        assert get_response.json()["analysis"] == test_manifest_json["analysis"]
 
 
 class TestPUT(object):

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -240,6 +240,7 @@ class TestDELETE(object):
     def test_success(self, flask_api_url, pytestconfig):
         """ Test successful delete (after successful upload).
         """
+        #Post
         test_manifest = os.path.join(
             str(pytestconfig.rootdir),
             'tests',
@@ -253,6 +254,13 @@ class TestDELETE(object):
         for id in post_response.json():
             assert UUID(id, version=4)
         assert post_response.status_code == 200
+        
+        # Delete
+        project_id = post_response.json()[0]
+        delete_response = requests.delete(flask_api_url + "/api/projects/" + project_id)
+        print(delete_response.text)
+        assert delete_response.status_code == 200
+
 
     def test_inconsistent_delete(self, flask_api_url, pytestconfig):
         test_manifest = os.path.join(

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -41,7 +41,8 @@ class TestPOST(object):
         )
         with open(test_manifest, 'r') as tf:
             test_manifest_json = json.load(tf)
-        response = requests.post(flask_api_url + "/api/projects", json=test_manifest_json)
+        response = requests.post(
+            flask_api_url + "/api/projects", json=test_manifest_json)
         print(response.text)
         for id in response.json():
             assert UUID(id, version=4)
@@ -130,7 +131,8 @@ class TestPOST(object):
         with open(unmatching_manifest, 'r', encoding='utf-8') as tf:
             unmatching_data = str(tf.read().replace('\n', ''))
         unmatching_response = requests.post(flask_api_url + "/api/projects",
-                                            data=unmatching_data.encode('utf-8'),
+                                            data=unmatching_data.encode(
+                                                'utf-8'),
                                             headers={'Content-Type': 'application/json5'})
         print(unmatching_response.text)
 
@@ -224,7 +226,8 @@ class TestDELETE(object):
         """ Test for 404 when a project with unknown ID is to be deleted.
         """
         unknown_id = str(uuid.uuid4())
-        response = requests.delete(flask_api_url + "/api/projects/" + unknown_id)
+        response = requests.delete(
+            flask_api_url + "/api/projects/" + unknown_id)
         print(response.text)
         assert response.status_code == 404
 
@@ -233,14 +236,15 @@ class TestDELETE(object):
             The method does expect a uuid, a string will return invalid method
         """
         invalid_id = "invalid"
-        response = requests.delete(flask_api_url + "/api/projects/" + invalid_id)
+        response = requests.delete(
+            flask_api_url + "/api/projects/" + invalid_id)
         print(response.text)
         assert response.status_code == 405
 
     def test_success(self, flask_api_url, pytestconfig):
         """ Test successful delete (after successful upload).
         """
-        #Post
+        # Post
         test_manifest = os.path.join(
             str(pytestconfig.rootdir),
             'tests',
@@ -249,18 +253,19 @@ class TestDELETE(object):
         )
         with open(test_manifest, 'r') as tf:
             test_manifest_json = json.load(tf)
-        post_response = requests.post(flask_api_url + "/api/projects", json=test_manifest_json)
+        post_response = requests.post(
+            flask_api_url + "/api/projects", json=test_manifest_json)
         print(post_response.text)
         for id in post_response.json():
             assert UUID(id, version=4)
         assert post_response.status_code == 200
-        
+
         # Delete
         project_id = post_response.json()[0]
-        delete_response = requests.delete(flask_api_url + "/api/projects/" + project_id)
+        delete_response = requests.delete(
+            flask_api_url + "/api/projects/" + project_id)
         print(delete_response.text)
         assert delete_response.status_code == 200
-
 
     def test_inconsistent_delete(self, flask_api_url, pytestconfig):
         test_manifest = os.path.join(
@@ -271,12 +276,14 @@ class TestDELETE(object):
         )
         with open(test_manifest, 'r') as tf:
             test_manifest_json = json.load(tf)
-        post_response = requests.post(flask_api_url + "/api/projects", json=test_manifest_json)
+        post_response = requests.post(
+            flask_api_url + "/api/projects", json=test_manifest_json)
         print(post_response.text)
         for id in post_response.json():
             assert UUID(id, version=4)
         project_id = post_response.json()[0]
-        delete_response = requests.delete(flask_api_url + "/api/projects/" + project_id)
+        delete_response = requests.delete(
+            flask_api_url + "/api/projects/" + project_id)
         print(delete_response.text)
         assert delete_response.status_code == 200
 
@@ -314,18 +321,21 @@ class TestGET(object):
         )
         with open(test_manifest, 'r') as tf:
             test_manifest_json = json.load(tf)
-        post_response = requests.post(flask_api_url + "/api/projects", json=test_manifest_json)
+        post_response = requests.post(
+            flask_api_url + "/api/projects", json=test_manifest_json)
         print(post_response.text)
         for id in post_response.json():
             assert UUID(id, version=4)
 
         project_id = post_response.json()[0]
-        get_response = requests.get(flask_api_url + "/api/projects/" + project_id)
+        get_response = requests.get(
+            flask_api_url + "/api/projects/" + project_id)
         print(get_response.text)
 
         assert get_response.status_code == 200
         assert get_response.json()["title"] == test_manifest_json["title"]
-        assert get_response.json()["analysis"] == test_manifest_json["analysis"]
+        assert get_response.json()["analysis"] == test_manifest_json[
+            "analysis"]
 
 
 class TestPUT(object):


### PR DESCRIPTION
Added test which should check if project deletions are correctly synced to elasticsearch for #187 .
Sorry for too many commits, it was either problems with pep8 or travis didn't run through because I forgot to give elasticsearch some time to update. And since my computer was faster I didn't notice what the problem was until commit nr. 8 (:

In addition I changed the _Project DELETE test for success_ because the part where the actual delete gets tested was missing.