### PR TITLE
[FRONTEND] possible revert of search API return

### DIFF
--- a/backend/api/projects.py
+++ b/backend/api/projects.py
@@ -103,16 +103,9 @@ def get_projects():
     else:
         return make_response('Invalid parameters', 400)
 
-    try:
-        res = [x for x in res[:]]
-        for project in res:
-            project['is_bookmark'] = 'true' if project['_id']\
-                in current_user['bookmarks'] else 'false'
-            project['is_owner'] = 'true' if current_user['email']\
-                in [author['email'] for author in project['authors']] else 'false'
-        return jsonify(res)
-    except KeyError as err:
-        raise ApiException(str(err), 400)
+    res = make_response(jsonify([x for x in res[:]]))
+    res.headers['Content-Type'] = 'application/json'
+    return res
 
 
 @projects.route('/api/projects/authors', methods=['GET'])
@@ -150,11 +143,11 @@ def get_project_by_id(project_id):
     if not res:
         return make_response("Project not found", 404)
     try:
-        res['is_bookmark'] = 'true' if project_id in current_user['bookmarks'] else 'false'
+        res['is_bookmark'] = 'true' if str(project_id) in current_user['bookmarks'] else 'false'
         res['is_owner'] = 'true' if current_user['email']\
             in [author['email'] for author in res['authors']] else 'false'
-    except KeyError as err:
-        raise ApiException(str(err), 500)
+    except KeyError:
+        pass
     return jsonify(res)
 
 

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -93,6 +93,8 @@ def update_user():
         res.last_name = user['last name']
         res.bio = user['bio']
         res.save()
+        res = make_response(jsonify(res))
+        res.headers['Content-Type'] = 'application/json'
 
         return make_response("User with email: " +
                              user['email'] + " updated", 200)
@@ -129,10 +131,11 @@ def get_user(mail):
     """
     user = g.user_datastore.get_user(mail)
     if not user:
-        return make_response("Unknown User with Email-address: " + str(mail), 400)
+        return make_response("Unknown User with Email-address: " + mail, 400)
 
     res = user.to_dict()
     res['roles'] = [role for role in ['admin', 'user'] if user.has_role(role)]
+
     return jsonify(res)
 
 
@@ -146,18 +149,6 @@ def insert_bookmarks(id):
         return make_response("Project is already bookmarked.", 400)
     user.bookmarks.append(id)
     user.save()
-    projects = [g.projects.find_one({'_id': project_id}) for project_id in user['bookmarks']]
-
-    try:
-        for project in projects:
-            project['is_bookmark'] = 'true'
-            project['is_owner'] = 'true' if current_user['email']\
-                in [author['email'] for author in project['authors']] else 'false'
-
-        return jsonify(projects)
-
-    except KeyError as err:
-        raise ApiException(str(err), 500)
     return jsonify(user['bookmarks'])
 
 
@@ -170,18 +161,7 @@ def delete_bookmarks(id):
     if id in user.bookmarks:
         user.bookmarks.remove(id)
         user.save()
-        projects = [g.projects.find_one({'_id': project_id}) for project_id in user['bookmarks']]
-
-        try:
-            for project in projects:
-                project['is_bookmark'] = 'true'
-                project['is_owner'] = 'true' if current_user['email']\
-                    in [author['email'] for author in project['authors']] else 'false'
-
-            return jsonify(projects)
-
-        except KeyError as err:
-            raise ApiException(str(err), 500)
+        return jsonify(user['bookmarks'])
     return make_response("Project is not bookmarked: " + str(id), 400)
 
 
@@ -191,15 +171,4 @@ def get_bookmarks():
     user = g.user_datastore.get_user(current_user['email'])
     if not user:
         raise ApiException("Couldn't find current_user in datastore", 500)
-    projects = [g.projects.find_one({'_id': project_id}) for project_id in user['bookmarks']]
-
-    try:
-        for project in projects:
-            project['is_bookmark'] = 'true'
-            project['is_owner'] = 'true' if current_user['email']\
-                in [author['email'] for author in project['authors']] else 'false'
-
-        return jsonify(projects)
-
-    except KeyError as err:
-        raise ApiException(str(err), 500)
+    return jsonify(user['bookmarks'])

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -320,10 +320,6 @@ class TestGET(object):
         print(projects[0])
         for project in projects:
             print(project)
-            if 'is_bookmark' in project:
-                del project['is_bookmark']
-            if 'is_owner' in project:
-                del project['is_owner']
             print(manifest_validator.is_valid(project))
             assert manifest_validator.is_valid(project)
             print("project_id: ", project["_id"])


### PR DESCRIPTION
Reverts Drakulix/knex#294

The current master branch returns` [ { project } ] `(a list of projects) from search api calls now. The `{ project }` objects have the fields `is_bookmark` and `is_owner` as requested.

However, the frontend currently still works with the old response from search, which was the elasticsearch query result with `results['hits']['hits']['_source']`. Therefore the frontend does currently not display any projects. If fixing this is a big thing and you need the master to work and prefer to work on the branch itself to implement those changes, please approve and revert this.