### PR TITLE
[BE] Fix role encoding

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -187,7 +187,7 @@ class User(DB.Document, UserMixin):
         dic['active'] = str(self.active)
         dic['bio'] = str(self.bio)
         dic['bookmarks'] = [str(bookmark) for bookmark in self.bookmarks]
-        dic['roles'] = [str(role) for role in self.roles]
+        dic['roles'] = [str(role.name) for role in self.roles]
         return dic
 
 

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -173,7 +173,6 @@ def get_user(mail):
         return make_response("Unknown User with Email-address: " + str(mail), 404)
 
     res = user.to_dict()
-    res['roles'] = [role for role in ['admin', 'user'] if user.has_role(role)]
     return jsonify(res)
 
 


### PR DESCRIPTION
Fixes how roles are returned from /api/users vs /api/user/email@address.com

Fix #369 